### PR TITLE
fixes markdown spacing problem - issue #478

### DIFF
--- a/_visual/colors.md
+++ b/_visual/colors.md
@@ -4,9 +4,7 @@ title: Colors
 order: 02
 ---
 
-<p>A flexible, yet distinctly American palette designed to communicate warmth and trustworthiness while meeting the highest standards of 508 color contrast requirements.</p>
-
-<a class="usa-button usa-button-primary-alt" href="{{ site.baseurl }}/assets/releases/wds-design-v0.8.zip">Download the design files</a>
+<p>A flexible, yet distinctly American palette designed to communicate warmth and trustworthiness while meeting the highest standards of 508 color contrast requirements.</p><a class="usa-button usa-button-primary-alt" href="{{ site.baseurl }}/assets/releases/wds-design-v0.8.zip">Download the design files</a>
 <p class="usa-text-small">Download a zip file with font files and color swatches.</p>
 
 <h3 class="usa-heading" id="palette">Palette</h3>


### PR DESCRIPTION
This PR fixes issue #478. As @maya pointed out, an extra `<p>` tag was getting inserted. Turns out kramdown, Jekyll’s Markdown processor, inserts a `<p>` tag when an `<a>` tag is started on a new line. I found this to be a useful tool for comparing different markdown implementations  :point_right:  [http://johnmacfarlane.net/babelmark2/](http://johnmacfarlane.net/babelmark2/). 

Screenshot is attached.
![screenshot 2015-10-18 10 11 01](https://github-cloud.s3.amazonaws.com/assets/4030051/10565353/49250304-7583-11e5-8aa1-fd6c7083e2d4.png)
